### PR TITLE
Update GitHub Workflows to Fix ReviewDog TFLint Action

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -1,0 +1,19 @@
+---
+name: feature-branch
+on:
+  pull_request:
+    branches:
+      - main
+      - release/**
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  pull-requests: write
+  id-token: write
+  contents: write
+  issues: write
+
+jobs:
+  terraform-module:
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/feature-branch.yml@main
+    secrets: inherit

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,0 +1,20 @@
+---
+name: release-branch
+on:
+  push:
+    branches:
+      - main
+      - release/v*
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'examples/**'
+      - 'test/**'
+      - 'README.md'
+
+permissions: {}
+
+jobs:
+  terraform-module:
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-branch.yml@main
+    secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -1,0 +1,13 @@
+---
+name: release-published
+on:
+  release:
+    types:
+      - published
+
+permissions: {}
+
+jobs:
+  terraform-module:
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/release-published.yml@main
+    secrets: inherit

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,16 @@
+---
+name: scheduled
+on:
+  workflow_dispatch: { }  # Allows manually trigger this workflow
+  schedule:
+    - cron: "0 3 * * *"
+
+permissions:
+  pull-requests: write
+  id-token: write
+  contents: write
+
+jobs:
+  scheduled:
+    uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/scheduled.yml@main
+    secrets: inherit


### PR DESCRIPTION
## what
- Update workflows (`.github/workflows`) to add `issue: write` permission needed by ReviewDog `tflint` action

## why
- The ReviewDog action will comment with line-level suggestions based on linting failures
